### PR TITLE
alternative attribute notation for goto

### DIFF
--- a/inc/jquery.mb.YTPlayer.js
+++ b/inc/jquery.mb.YTPlayer.js
@@ -882,9 +882,9 @@ function onYouTubePlayerAPIReady() {
 				YTPlayer.timeW = e.clientX - timeBar.offset().left;
 				controlBar.find(".mb_YTVPLoaded").css({width: 0});
 				var totalTime = Math.floor(YTPlayer.player.getDuration());
-				YTPlayer.goto = (timeBar.outerWidth() * totalTime) / progressBar.outerWidth();
+				YTPlayer['goto'] = (timeBar.outerWidth() * totalTime) / progressBar.outerWidth();
 
-				YTPlayer.player.seekTo(parseFloat(YTPlayer.goto), true);
+				YTPlayer.player.seekTo(parseFloat(YTPlayer['goto']), true);
 				controlBar.find(".mb_YTVPLoaded").css({width: 0});
 			});
 


### PR DESCRIPTION
Keywords and reserved words are not allowed as unquoted property names in older versions of JavaScript (goto was reserved prior to ECMAScript 5).

This raises warnings or errors in Google’s Closure Compiler, depending on its settings.

https://en.wikibooks.org/wiki/JavaScript/Reserved_Words