### PR TITLE
use outerWidth and outerHeight for el dimensions

### DIFF
--- a/inc/jquery.mb.YTPlayer.js
+++ b/inc/jquery.mb.YTPlayer.js
@@ -1020,8 +1020,8 @@ function onYouTubePlayerAPIReady() {
 		var win = {};
 		var el = !YTPlayer.isBackground ? data.containment : jQuery(window);
 
-		win.width = el.width();
-		win.height = el.height();
+		win.width = el.outerWidth();
+		win.height = el.outerHeight();
 
 		var margin = 24;
 		var vid = {};


### PR DESCRIPTION
I had an issue where padding of the container element wasn't granted for.
This resulted in the video having a black bar on the right side (with a size equal to the combined horizontal padding).
Using the outerWidth and outerHeight jQuery methods solved this problem.
