### PR TITLE
Prevents getting stuck, if embedding is restricted

### DIFF
--- a/inc/jquery.mb.YTPlayer.js
+++ b/inc/jquery.mb.YTPlayer.js
@@ -498,6 +498,13 @@ function onYouTubePlayerAPIReady() {
 								},
 								'onError'                : function (err) {
 
+									if (err.data == 150)
+									{
+										console.log("Embedding this video is restricted by Youtube.");
+										if (YTPlayer.isPlayList)
+											jQuery(YTPlayer).playNext();
+									}
+
 									if (err.data == 2 && YTPlayer.isPlayList)
 										jQuery(YTPlayer).playNext();
 


### PR DESCRIPTION
There are multiple reasons for this to happen, most notably, if there is a copyright claim on the video or age confirmation is required...

Logging it to the developer console, is a personal preference.
At least it would have saved me a lot of time, because if the video doesn't react to pressing play, I was at least expecting some sort of Javascript exception, which would explain this to me...
