### PR TITLE
Prevent Iframe access error

### DIFF
--- a/inc/jquery.mb.YTPlayer.js
+++ b/inc/jquery.mb.YTPlayer.js
@@ -149,9 +149,14 @@ function onYouTubePlayerAPIReady() {
 					property.vol = property.vol == 0 ? property.vol = 1: property.vol;
 
 				jQuery.extend(YTPlayer.opt, jQuery.mbYTPlayer.defaults, options, property);
-
-				var canGoFullscreen = !(jQuery.browser.msie || jQuery.browser.opera || self.location.href != top.location.href);
-
+				
+				
+				try{
+		                    var canGoFullscreen = !(jQuery.browser.msie || jQuery.browser.opera || self.location.href != top.location.href);
+		                } catch(Exception){
+		                    var canGoFullscreen = false;
+		                }
+		                
 				if (!canGoFullscreen)
 					YTPlayer.opt.realfullscreen = false;
 


### PR DESCRIPTION
I have this error when the script is embedded in iframe (ie. in a Facebook App or loaded from another subdomain) : 

Uncaught SecurityError: Blocked a frame with origin "http://xxxx" from accessing a frame with origin "http://localhost". Protocols, domains, and ports must match.  @line jquery.mb.YTPlayer.js:153

I put quickly this to fix it : 

try{
    var canGoFullscreen = !(jQuery.browser.msie || jQuery.browser.opera || self.location.href != top.location.href);
} catch(Exception){
    var canGoFullscreen = false;
}

So now the script works even if loaded from an iframe or another domain or in a Facebook apps. I don't know what will be your strategy for this (if you want also to check jQuery.browser.msie or if we have access to the top.location.href) => so I propose the safer way with a try method and if any error => canGoFullscreen = false.
