### PR TITLE
fix "property is undefined" error

### DIFF
--- a/inc/jquery.mb.YTPlayer.js
+++ b/inc/jquery.mb.YTPlayer.js
@@ -143,7 +143,7 @@ function onYouTubePlayerAPIReady() {
 
 				var property = $YTPlayer.data("property") && typeof $YTPlayer.data("property") == "string" ? eval('(' + $YTPlayer.data("property") + ')') : $YTPlayer.data("property");
 
-				if(typeof property.vol != "undefined")
+				if(typeof property != "undefined" && typeof property.vol != "undefined")
 					property.vol = property.vol == 0 ? property.vol = 1: property.vol;
 
 				jQuery.extend(YTPlayer.opt, jQuery.mbYTPlayer.defaults, options, property);


### PR DESCRIPTION
"TypeError: property is undefined" error occurs when `data-property` attribute dosen't exist.
