### PR TITLE
Insert Youtube iframe api script as first chile of <head> tag, instead of inserting it after <title> tag

### DIFF
--- a/inc/jquery.mb.YTPlayer.js
+++ b/inc/jquery.mb.YTPlayer.js
@@ -274,7 +274,7 @@ function onYouTubePlayerAPIReady() {
 				if (!ytp.YTAPIReady) {
 					jQuery("#YTAPI").remove();
 					var tag = jQuery("<script></script>").attr({"src": jQuery.mbYTPlayer.locationProtocol + "//www.youtube.com/player_api?v=" + jQuery.mbYTPlayer.version, "id": "YTAPI"});
-					jQuery("head title").after(tag);
+					jQuery("head").prepend(tag);
 				} else {
 					setTimeout(function () {
 						jQuery(document).trigger("YTAPIReady");


### PR DESCRIPTION
Hello!

I tried to use plugin in our project, and spend a lot of time to find out why there is no video on my page in the background. The most interesting thing i noticed, is that there were no any errors in console. When i decided to write my own plugin and began to read youtube api documentation, i find out in documentation that i must wait while youtube api script is loading. Then i look at the console again: script was not uploaded. And then i found, that <script> tag should be inserted after <title> tag... Yes, there was no<title> tag at our project.
It is not obviously for developers why video is not playing if they have the same situation as me. So, i tried to fix this.

And thank you for such good plugin! Best regards!