### PR TITLE
Added missing clearTimeout

### DIFF
--- a/src/jquery.mb.YTPlayer.src.js
+++ b/src/jquery.mb.YTPlayer.src.js
@@ -846,6 +846,7 @@ var getYTPVideoID = function( url ) {
 				YTPlayer.isAlone = true;
 			} else {
 				jQuery( document ).off( "mousemove.YTPlayer" );
+				clearTimeout( YTPlayer.hideCursor );
 				YTPlayer.overlay.css( {
 					cursor: "auto"
 				} );


### PR DESCRIPTION
Currently, if a user quickly enters and exits fullscreen and then does not move his mouse until the timeout fires, his cursor will disappear even though he is no longer in fullscreen mode.

This happens because of a missing clearTimeout when the user exits fullscreen.